### PR TITLE
step-1: scaffold express server with health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # alteon-mcp
+
+Minimal MCP server for Radware Alteon REST APIs.
+
+## Development
+
+```bash
+pnpm dev
+pnpm test
+```
+
+The development server listens on http://localhost:8787.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,12 @@
+# Roadmap
+
+- [x] Step 1 — Scaffold basic server.
+- [ ] Step 2 — Types & HTTP client + Profile Manager.
+- [ ] Step 3 — getRole (Read-only).
+- [ ] Step 4 — getApplyStatus (Read-only).
+- [ ] Step 5 — exportConfig (Read-only, binary).
+- [ ] Step 6 — applyConfig (Mutating + confirmation).
+- [ ] Step 7 — Descriptor Registry (Extensibility).
+- [ ] Step 8 — Wire Real/Group/Virtual to real APIs.
+- [ ] Step 9 — MCP stdio adapter.
+- [ ] Step 10 — Packaging (Docker + systemd) and README.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "alteon-mcp",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "nodemon --watch src --exec ts-node src/http-server.ts",
+    "build": "tsc",
+    "start": "node dist/http-server.js",
+    "test": "node --require ts-node/register --test tests/**/*.test.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^1.6.8",
+    "express": "^4.18.2",
+    "yaml": "^2.3.4",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.19",
+    "@types/supertest": "^2.0.12",
+    "nodemon": "^3.0.2",
+    "supertest": "^6.3.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  },
+  "packageManager": "pnpm@10.5.2"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,29 @@
+import express, { Request, Response, NextFunction } from 'express';
+
+// Create the Express application
+const app = express();
+const PORT = process.env.PORT || 8787;
+
+// Health check endpoint to confirm server is running
+app.get('/health', (_req: Request, res: Response) => {
+  res.json({ ok: true });
+});
+
+// Generic error handler to provide insight if something goes wrong
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+  console.error('Unhandled error:', err);
+  res.status(500).json({ error: 'Internal Server Error', message: err.message });
+});
+
+// Start the server when this file is executed directly
+if (require.main === module) {
+  app
+    .listen(PORT, () => {
+      console.log(`HTTP server listening on http://localhost:${PORT}`);
+    })
+    .on('error', (err) => {
+      console.error('Failed to start server:', err);
+    });
+}
+
+export default app;

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,9 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import request from 'supertest';
+import app from '../src/http-server';
+
+test('GET /health returns ok:true', async () => {
+  const res = await request(app).get('/health');
+  assert.deepStrictEqual(res.body, { ok: true });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- initialize TypeScript/Node project structure
- add Express-based HTTP server with `/health` endpoint and error handling
- set up test harness, scripts, README, and roadmap

## Testing
- `pnpm dev` *(fails: nodemon: not found)*
- `pnpm test` *(fails: Cannot find module 'ts-node/register')*
- `curl -i http://localhost:8787/health` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_68c122f0dee48324a5b319416cf98ad9